### PR TITLE
Fix Hidden and Ghost Notes For ReBeat

### DIFF
--- a/src/Enhancers/MapEnhancer.cpp
+++ b/src/Enhancers/MapEnhancer.cpp
@@ -34,11 +34,13 @@ vector<string> MapEnhancer::Modifiers() const {
     vector<string> result;
 
     static auto reBeatEnabledFunc = CondDeps::Find<bool>("rebeat", "GetEnabled");
+    static auto reBeatHiddenFunc = CondDeps::Find<bool>("rebeat", "GetHidden");
     static auto reBeatSameColorFunc = CondDeps::Find<bool>("rebeat", "GetSameColor");
     static auto reBeatEasyFunc = CondDeps::Find<bool>("rebeat", "GetEasyMode");
     static auto reBeatOneHpFunc = CondDeps::Find<bool>("rebeat", "GetOneHP");
 
     bool reBeatEnabled = reBeatEnabledFunc.has_value() && reBeatEnabledFunc.value()();
+    bool reBeatHidden = reBeatHiddenFunc.has_value() && reBeatHiddenFunc.value()();
     bool reBeatSameColor = reBeatSameColorFunc.has_value() && reBeatSameColorFunc.value()();
     bool reBeatEasy = reBeatEasyFunc.has_value() && reBeatEasyFunc.value()();
     bool reBeatOneHp = reBeatOneHpFunc.has_value() && reBeatOneHpFunc.value();
@@ -47,14 +49,7 @@ vector<string> MapEnhancer::Modifiers() const {
     if (gameplayModifiers->songSpeed == GameplayModifiers::SongSpeed::Faster) { result.emplace_back("FS"); }
     if (gameplayModifiers->songSpeed == GameplayModifiers::SongSpeed::Slower) { result.emplace_back("SS"); }
     if (gameplayModifiers->songSpeed == GameplayModifiers::SongSpeed::SuperFast) { result.emplace_back("SF"); }
-    if (reBeatEnabled) {
-        static auto reBeatHiddenFunc = CondDeps::Find<bool>("rebeat", "GetHidden");
-        if (reBeatHiddenFunc.has_value() && reBeatHiddenFunc.value()()) {
-            result.emplace_back("HD");
-        }
-    } else if (gameplayModifiers->ghostNotes) {
-        result.emplace_back("GN");
-    }
+    if (gameplayModifiers->ghostNotes && !(reBeatEnabled && reBeatHidden)) { result.emplace_back("GN"); }
     if (gameplayModifiers->noArrows) { result.emplace_back("NA"); }
     if (gameplayModifiers->noBombs) { result.emplace_back("NB"); }
     if (gameplayModifiers->noFailOn0Energy && energy == 0) { result.emplace_back("NF"); }
@@ -68,6 +63,7 @@ vector<string> MapEnhancer::Modifiers() const {
 
     // ReBeat Modifier Support
 
+    if (reBeatEnabled && reBeatHidden) { result.emplace_back("HD"); }
     if (reBeatEnabled && reBeatSameColor) { result.emplace_back("SMC"); }
     if (reBeatEnabled && reBeatEasy) { result.emplace_back("EZ"); }
     if (reBeatEnabled && reBeatOneHp) { result.emplace_back("OHP"); }


### PR DESCRIPTION
ReBeat _does_ allow the user to enable ghost notes as a legacy modifier. This corrects the mistake of it ignoring ghost notes if rebeat is enabled.